### PR TITLE
Adjust text filter threshold

### DIFF
--- a/Purchasing Plate Weight V1.05.html
+++ b/Purchasing Plate Weight V1.05.html
@@ -136,7 +136,7 @@ function handleFiles(files) {
         const x = item.transform[4];
         const y = item.transform[5];
 
-        if (x > w * 0.55 && y > h * 0.15) {
+        if (x > w * 0.8 && y > h * 0.15) {
           debugLog.push(`Text: '${item.str}' @ x:${x.toFixed(1)}, y:${y.toFixed(1)} --> Included`);
           ctx.strokeStyle = "rgba(255, 0, 0, 0.5)";
           ctx.strokeRect(x, canvas.height - y, 50, 12);


### PR DESCRIPTION
## Summary
- tweak `x` filter for parsed text blocks

## Testing
- `node -e "const fs=require('fs');const path=require('path');const pdfjs=require('pdfjs-dist/legacy/build/pdf.mjs');(async()=>{const data=new Uint8Array(fs.readFileSync('Test Cut List After OCR.pdf'));const pdf=await pdfjs.getDocument({data,standardFontDataUrl:path.join(__dirname,'node_modules/pdfjs-dist/standard_fonts/')}).promise;const page=await pdf.getPage(1);const viewport=page.getViewport({scale:1});const w=viewport.width;const h=viewport.height;const content=await page.getTextContent();content.items.forEach(i=>{const x=i.transform[4];if(x>390&&x<460){console.log('dimension',i.str,x);}if(x>w*0.8){console.log('weightCandidate',i.str,x);}});})();"

------
https://chatgpt.com/codex/tasks/task_e_68485f60914c832482ced5f841c1bd42