### PR TITLE
Add Y filter to ignore title header weights

### DIFF
--- a/Purchasing Plate Weight V1.05.html
+++ b/Purchasing Plate Weight V1.05.html
@@ -130,11 +130,14 @@ function handleFiles(files) {
 
         const textContent = await page.getTextContent();
         const w = viewport.width;
+        const h = viewport.height;
         const lineGroups = new Map();
         textContent.items.forEach(item => {
           const x = item.transform[4];
-          if (x > w * 0.8) {
-            const y = Math.round(item.transform[5]);
+          const yRaw = item.transform[5];
+          // Exclude tokens near the top title block
+          if (x > w * 0.8 && yRaw > h * 0.15) {
+            const y = Math.round(yRaw);
             if (!lineGroups.has(y)) lineGroups.set(y, []);
             lineGroups.get(y).push(item.str);
           }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Main function of this script is to extract weight of steel plates from cut list,
 ### Current limitations
 - Drag-and-drop upload is still pending; use the file picker for now.
 - No OCR support, so scanned PDFs cannot be read.
+- The script skips tokens near the top of the page to avoid title block
+  numbers. Adjust the `0.15` Y-threshold in the HTML if your layout
+  differs.
 
 ### To do / planned improvements
 - Add OCR functionality within the HTML script.


### PR DESCRIPTION
## Summary
- filter out text near the top of each page when parsing the PDF
- clarify this Y-threshold in the documentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68485037f27083248e654955c40472fb