### PR TITLE
Handle header value near top of first page

### DIFF
--- a/Purchasing Plate Weight V1.05.html
+++ b/Purchasing Plate Weight V1.05.html
@@ -135,8 +135,10 @@ function handleFiles(files) {
         textContent.items.forEach(item => {
           const x = item.transform[4];
           const yRaw = item.transform[5];
+          // Skip page 1 header text very near the top (y ~ 768 on letter pages)
+          const isTopOfFirstPage = i === 1 && yRaw > h * 0.97;
           // Exclude tokens near the top title block
-          if (x > w * 0.8 && yRaw > h * 0.15) {
+          if (!isTopOfFirstPage && x > w * 0.8 && yRaw > h * 0.15) {
             const y = Math.round(yRaw);
             if (!lineGroups.has(y)) lineGroups.set(y, []);
             lineGroups.get(y).push(item.str);

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Main function of this script is to extract weight of steel plates from cut list,
 - The script skips tokens near the top of the page to avoid title block
   numbers. Adjust the `0.15` Y-threshold in the HTML if your layout
   differs.
+- Page 1 has an additional rule that ignores text very close to the
+  top margin (around y=768 on letter pages) to suppress header values.
 
 ### To do / planned improvements
 - Add OCR functionality within the HTML script.


### PR DESCRIPTION
## Summary
- ignore page 1 text extremely close to the top
- document header skipping logic in README

## Testing
- `pip install pdfminer.six` *(for inspection)*

------
https://chatgpt.com/codex/tasks/task_e_684877e91e208324ae39d56ab8a4a631