### PR TITLE
Update top threshold logic

### DIFF
--- a/Purchasing Plate Weight V1.05.html
+++ b/Purchasing Plate Weight V1.05.html
@@ -156,8 +156,8 @@ async function handleFiles(files) {
         const yRaw = item.transform[5];
         // Skip page 1 header text very near the top (y ~ 768 on letter pages)
         const isTopOfFirstPage = i === 1 && yRaw > h * 0.97;
-        // Exclude tokens near the top title block
-        if (!isTopOfFirstPage && x > w * 0.8 && yRaw > h * 0.15) {
+        // Exclude tokens in the top 15% of the page (title block area)
+        if (!isTopOfFirstPage && x > w * 0.8 && yRaw < h * 0.85) {
           const y = Math.round(yRaw);
           if (!lineGroups.has(y)) lineGroups.set(y, []);
           lineGroups.get(y).push(item.str);

--- a/Purchasing Plate Weight V1.06.html
+++ b/Purchasing Plate Weight V1.06.html
@@ -179,8 +179,8 @@ async function handleFiles(files) {
         const yRaw = item.transform[5];
         // Skip page 1 header text very near the top (y ~ 768 on letter pages)
         const isTopOfFirstPage = i === 1 && yRaw > h * 0.97;
-        // Exclude tokens near the top title block
-        if (!isTopOfFirstPage && x > w * 0.8 && yRaw > h * 0.15) {
+        // Exclude tokens in the top 15% of the page (title block area)
+        if (!isTopOfFirstPage && x > w * 0.8 && yRaw < h * 0.85) {
           const y = Math.round(yRaw);
           if (!lineGroups.has(y)) lineGroups.set(y, []);
           lineGroups.get(y).push(item.str);

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Main function of this script is to extract weight of steel plates from cut list,
 - OCR is provided via Tesseract.js but may be slow or inaccurate for complex
   scans.
 - The script skips tokens near the top of the page to avoid title block
-  numbers. Adjust the `0.15` Y-threshold in the HTML if your layout
-  differs.
+  numbers. The comparison uses `0.85` (meaning 85% of the page height) to
+  exclude the top 15% of the page. Adjust this threshold in the HTML if your
+  layout differs.
 - Page 1 has an additional rule that ignores text very close to the
   top margin (around y=768 on letter pages) to suppress header values.
 


### PR DESCRIPTION
## Summary
- adjust filter threshold to `< h * 0.85` for top 15% exclusion
- clarify comment in HTML files
- document new threshold in README

## Testing
- `node parse.js 'Test Cut List After OCR.pdf' 2>/dev/null > debug.log` *(used during development)*

------
https://chatgpt.com/codex/tasks/task_e_6848b9c669088324ae08f47a3715d24d