### PR TITLE
Update parsing anchor and annotate PDFs

### DIFF
--- a/Purchasing Plate Weight V1.05.html
+++ b/Purchasing Plate Weight V1.05.html
@@ -11,6 +11,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/2.1.5/tesseract.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Roboto', sans-serif; background: #f9f9f9; color: #333; padding: 20px; }
@@ -96,6 +97,7 @@
 <div id="debug"></div>
 <button id="download" style="display:none">Download as Excel</button>
 <button id="downloadPdf" style="display:none">Download as PDF</button>
+<button id="annotatePdf" style="display:none">Download Annotated PDF</button>
 <button id="toggleDebug">Show Debug Log</button>
 
 <script>
@@ -108,8 +110,11 @@ const canvas = document.getElementById("pdf-canvas");
 const ctx = canvas.getContext("2d");
 const downloadBtn = document.getElementById("download");
 const downloadPdfBtn = document.getElementById("downloadPdf");
+const annotatePdfBtn = document.getElementById("annotatePdf");
 const toggleDebug = document.getElementById("toggleDebug");
 let cleanData = [];
+let currentTotalWeight = 0;
+let originalPdfBytes;
 
 ["dragenter", "dragover"].forEach(evt => {
   dropArea.addEventListener(evt, e => {
@@ -137,6 +142,7 @@ async function handleFiles(files) {
   const reader = new FileReader();
   reader.onload = async function() {
     const typedarray = new Uint8Array(this.result);
+    originalPdfBytes = this.result;
     const pdf = await pdfjsLib.getDocument({ data: typedarray }).promise;
     let extractedLines = [];
     let debugLog = [];
@@ -151,13 +157,20 @@ async function handleFiles(files) {
       const w = viewport.width;
       const h = viewport.height;
       const lineGroups = new Map();
+      const camber = textContent.items.find(t => /camber/i.test(t.str));
+      let startX = w * 0.8;
+      let startY = h * 0.85;
+      if (camber) {
+        startX = camber.transform[4] + w * 0.058;
+        startY = camber.transform[5] - h * 0.01;
+      }
       textContent.items.forEach(item => {
         const x = item.transform[4];
         const yRaw = item.transform[5];
         // Skip page 1 header text very near the top (y ~ 768 on letter pages)
         const isTopOfFirstPage = i === 1 && yRaw > h * 0.97;
-        // Exclude tokens near the top title block
-        if (!isTopOfFirstPage && x > w * 0.8 && yRaw > h * 0.15) {
+        // Capture weights starting after the camber reference
+        if (!isTopOfFirstPage && x > startX && yRaw < startY) {
           const y = Math.round(yRaw);
           if (!lineGroups.has(y)) lineGroups.set(y, []);
           lineGroups.get(y).push(item.str);
@@ -204,9 +217,11 @@ function processText(lines) {
   });
   html += '</table>';
   output.innerHTML = html;
+  currentTotalWeight = totalWeight;
   summary.innerText = `Total Weight: ${totalWeight.toLocaleString()} lbs | Estimated Cost: $${(totalWeight * 0.95).toLocaleString(undefined, { minimumFractionDigits: 2 })}`;
   downloadBtn.style.display = "inline-block";
   downloadPdfBtn.style.display = "inline-block";
+  annotatePdfBtn.style.display = "inline-block";
 }
 
 downloadBtn.addEventListener("click", () => {
@@ -230,6 +245,37 @@ downloadPdfBtn.addEventListener("click", () => {
     }
   });
   doc.save("cleaned_weights.pdf");
+});
+
+annotatePdfBtn.addEventListener("click", async () => {
+  if (!originalPdfBytes) return;
+  const { PDFDocument, StandardFonts, rgb } = PDFLib;
+  const pdfDoc = await PDFDocument.load(originalPdfBytes);
+  const pages = pdfDoc.getPages();
+  const first = pages[0];
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  first.drawText(`Total Weight: ${currentTotalWeight.toLocaleString()} lbs`, {
+    x: 50,
+    y: 40,
+    size: 12,
+    font,
+    color: rgb(0, 0, 0)
+  });
+  first.drawText(`Price: $${(currentTotalWeight * 0.95).toLocaleString(undefined, { minimumFractionDigits: 2 })}`, {
+    x: 50,
+    y: 25,
+    size: 12,
+    font,
+    color: rgb(0, 0, 0)
+  });
+  const bytes = await pdfDoc.save();
+  const blob = new Blob([bytes], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'annotated.pdf';
+  a.click();
+  URL.revokeObjectURL(url);
 });
 </script>
 </body>

--- a/Purchasing Plate Weight V1.06.html
+++ b/Purchasing Plate Weight V1.06.html
@@ -11,6 +11,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/2.1.5/tesseract.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Roboto', sans-serif; background: #f9f9f9; color: #333; padding: 20px; }
@@ -96,6 +97,7 @@
 <div id="debug"></div>
 <button id="download" style="display:none">Download as Excel</button>
 <button id="downloadPdf" style="display:none">Download as PDF</button>
+<button id="annotatePdf" style="display:none">Download Annotated PDF</button>
 <button id="toggleDebug">Show Debug Log</button>
 
 <script>
@@ -108,8 +110,11 @@ const canvas = document.getElementById("pdf-canvas");
 const ctx = canvas.getContext("2d");
 const downloadBtn = document.getElementById("download");
 const downloadPdfBtn = document.getElementById("downloadPdf");
+const annotatePdfBtn = document.getElementById("annotatePdf");
 const toggleDebug = document.getElementById("toggleDebug");
 let cleanData = [];
+let currentTotalWeight = 0;
+let originalPdfBytes;
 
 const featureStatus = {
   ocr: typeof Tesseract !== 'undefined',
@@ -160,6 +165,7 @@ async function handleFiles(files) {
   const reader = new FileReader();
   reader.onload = async function() {
     const typedarray = new Uint8Array(this.result);
+    originalPdfBytes = this.result;
     const pdf = await pdfjsLib.getDocument({ data: typedarray }).promise;
     let extractedLines = [];
     let debugLog = [];
@@ -174,13 +180,20 @@ async function handleFiles(files) {
       const w = viewport.width;
       const h = viewport.height;
       const lineGroups = new Map();
+      const camber = textContent.items.find(t => /camber/i.test(t.str));
+      let startX = w * 0.8;
+      let startY = h * 0.85;
+      if (camber) {
+        startX = camber.transform[4] + w * 0.058;
+        startY = camber.transform[5] - h * 0.01;
+      }
       textContent.items.forEach(item => {
         const x = item.transform[4];
         const yRaw = item.transform[5];
         // Skip page 1 header text very near the top (y ~ 768 on letter pages)
         const isTopOfFirstPage = i === 1 && yRaw > h * 0.97;
-        // Exclude tokens near the top title block
-        if (!isTopOfFirstPage && x > w * 0.8 && yRaw > h * 0.15) {
+        // Capture weights starting after the camber reference
+        if (!isTopOfFirstPage && x > startX && yRaw < startY) {
           const y = Math.round(yRaw);
           if (!lineGroups.has(y)) lineGroups.set(y, []);
           lineGroups.get(y).push(item.str);
@@ -227,9 +240,11 @@ function processText(lines) {
   });
   html += '</table>';
   output.innerHTML = html;
+  currentTotalWeight = totalWeight;
   summary.innerText = `Total Weight: ${totalWeight.toLocaleString()} lbs | Estimated Cost: $${(totalWeight * 0.95).toLocaleString(undefined, { minimumFractionDigits: 2 })}`;
   downloadBtn.style.display = "inline-block";
   downloadPdfBtn.style.display = "inline-block";
+  annotatePdfBtn.style.display = "inline-block";
 }
 
 downloadBtn.addEventListener("click", () => {
@@ -253,6 +268,37 @@ downloadPdfBtn.addEventListener("click", () => {
     }
   });
   doc.save("cleaned_weights.pdf");
+});
+
+annotatePdfBtn.addEventListener("click", async () => {
+  if (!originalPdfBytes) return;
+  const { PDFDocument, StandardFonts, rgb } = PDFLib;
+  const pdfDoc = await PDFDocument.load(originalPdfBytes);
+  const pages = pdfDoc.getPages();
+  const first = pages[0];
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  first.drawText(`Total Weight: ${currentTotalWeight.toLocaleString()} lbs`, {
+    x: 50,
+    y: 40,
+    size: 12,
+    font,
+    color: rgb(0, 0, 0)
+  });
+  first.drawText(`Price: $${(currentTotalWeight * 0.95).toLocaleString(undefined, { minimumFractionDigits: 2 })}`, {
+    x: 50,
+    y: 25,
+    size: 12,
+    font,
+    color: rgb(0, 0, 0)
+  });
+  const bytes = await pdfDoc.save();
+  const blob = new Blob([bytes], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'annotated.pdf';
+  a.click();
+  URL.revokeObjectURL(url);
 });
 </script>
 </body>

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Main function of this script is to extract weight of steel plates from cut list,
    The HTML file loads **pdf.js**, **xlsx**, and **jsPDF** directly from CDNs so
    no extra installation is required.
 3. Use the file picker or drag-and-drop area to load cut list PDFs. The script
-   extracts the weight values, sums them and displays the total along with
-   download options for Excel and PDF.
+  extracts the weight values, sums them and displays the total along with
+  download options for Excel, a plain PDF, or an annotated version of the
+  original PDF showing the weight and price.
 
 ### Dependencies
 - **pdf.js** – parses PDF files in the browser.
@@ -21,9 +22,9 @@ Main function of this script is to extract weight of steel plates from cut list,
 ### Current limitations
 - OCR is provided via Tesseract.js but may be slow or inaccurate for complex
   scans.
-- The script skips tokens near the top of the page to avoid title block
-  numbers. Adjust the `0.15` Y-threshold in the HTML if your layout
-  differs.
+- The script looks for the word `camber` near the top of each page and starts
+  reading weights 1% of the page height below the `R` character. This approach
+  skips the title region and adapts to slight layout changes.
 - Page 1 has an additional rule that ignores text very close to the
   top margin (around y=768 on letter pages) to suppress header values.
 


### PR DESCRIPTION
## Summary
- use the word `camber` as an anchor for weight extraction
- add ability to annotate the uploaded PDF with total weight and cost
- document new parsing logic and download option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848b9c669088324ae08f47a3715d24d