### PR TITLE
Update parser to use camber anchor

### DIFF
--- a/Purchasing Plate Weight V1.06.html
+++ b/Purchasing Plate Weight V1.06.html
@@ -172,23 +172,26 @@ async function handleFiles(files) {
 
       const textContent = await page.getTextContent();
       const w = viewport.width;
-      const h = viewport.height;
       const lineGroups = new Map();
       textContent.items.forEach(item => {
         const x = item.transform[4];
         const yRaw = item.transform[5];
-        // Skip page 1 header text very near the top (y ~ 768 on letter pages)
-        const isTopOfFirstPage = i === 1 && yRaw > h * 0.97;
-        // Exclude tokens in the top 15% of the page (title block area)
-        if (!isTopOfFirstPage && x > w * 0.8 && yRaw < h * 0.85) {
+        if (x > w * 0.8) {
           const y = Math.round(yRaw);
           if (!lineGroups.has(y)) lineGroups.set(y, []);
           lineGroups.get(y).push(item.str);
         }
       });
+
+      let capture = false;
       lineGroups.forEach((tokens, y) => {
         const line = tokens.join("").trim();
-        if (line) {
+        if (/camber/i.test(line)) {
+          capture = true;
+          debugLog.push(`Page ${i}: found camber anchor at y=${y}`);
+          return;
+        }
+        if (capture && line) {
           extractedLines.push(line);
           debugLog.push(`Page ${i}: (y=${y}) ${line}`);
         }

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Main function of this script is to extract weight of steel plates from cut list,
 ### Current limitations
 - OCR is provided via Tesseract.js but may be slow or inaccurate for complex
   scans.
-- The script skips tokens near the top of the page to avoid title block
-  numbers. The comparison uses `0.85` (meaning 85% of the page height) to
-  exclude the top 15% of the page. Adjust this threshold in the HTML if your
-  layout differs.
-- Page 1 has an additional rule that ignores text very close to the
-  top margin (around y=768 on letter pages) to suppress header values.
+- Parsing relies on finding the "Camber" column header to start reading the
+  weight values from the rightmost column. If that anchor is missing or spelled
+  differently the results may be incorrect.
 
 ### To do / planned improvements
 - Allow configuring the cost multiplier.
 - Support additional export formats such as CSV.
 - Provide UI controls for adjusting parsing thresholds.
+- Add an input area where the user can specify a PO number.
+- Place the total weight, dollar value and the entered PO number onto the
+  generated PDF before returning it to the user.


### PR DESCRIPTION
## Summary
- parse weight rows starting after the `Camber` header instead of skipping page headers
- update documentation to describe new parsing approach
- list upcoming features for PO entry and PDF output

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af897681c8324be183ae27802be1d