### PR TITLE
Add summary section to PDF export

### DIFF
--- a/Purchasing Plate Weight V1.06.html
+++ b/Purchasing Plate Weight V1.06.html
@@ -280,12 +280,24 @@ downloadPdfBtn.addEventListener("click", () => {
   const doc = new jsPDF();
   doc.setFontSize(10);
   let y = 10;
+
   if (poNumber) {
     doc.text(`PO Number: ${poNumber}`, 10, y);
     y += 7;
   }
 
-  cleanData.forEach(row => {
+  doc.text(`Total Weight: ${totalWeight.toLocaleString()} lbs`, 10, y);
+  y += 7;
+  doc.text(
+    `Estimated Cost: $${(totalWeight * costMultiplier).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+    })}`,
+    10,
+    y
+  );
+  y += 10;
+
+  cleanData.forEach((row) => {
     doc.text(`Weight: ${row.weight.toLocaleString()} lbs`, 10, y);
     y += 7;
     if (y > 280) {
@@ -293,10 +305,7 @@ downloadPdfBtn.addEventListener("click", () => {
       y = 10;
     }
   });
-  y += 10;
-  doc.text(`Total Weight: ${totalWeight.toLocaleString()} lbs`, 10, y);
-  y += 7;
-  doc.text(`Estimated Cost: $${(totalWeight * costMultiplier).toLocaleString(undefined, { minimumFractionDigits: 2 })}`, 10, y);
+
   doc.save("cleaned_weights.pdf");
 });
 </script>

--- a/README.md
+++ b/README.md
@@ -33,9 +33,5 @@ Main function of this script is to extract weight of steel plates from cut list,
 
 
 ### To do / planned improvements
-- Cost multiplier configuration implemented
 - Support additional export formats such as CSV.
 - Provide UI controls for adjusting parsing thresholds.
-- Add an input area where the user can specify a PO number.
-- Place the total weight, dollar value and the entered PO number onto the
-  generated PDF before returning it to the user.


### PR DESCRIPTION
## Summary
- show PO number, total weight, and estimated cost at the top of the generated PDF
- trim README todo section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b23111cb4832484991f3763007079