### PR TITLE
Add optional OCR processing

### DIFF
--- a/Purchasing Plate Weight V1.06.html
+++ b/Purchasing Plate Weight V1.06.html
@@ -99,6 +99,7 @@
 <div style="margin-top:10px">
   <label for="poNumber">PO Number:</label>
   <input type="text" id="poNumber" style="width:120px">
+  <label style="margin-left:10px"><input type="checkbox" id="ocrToggle"> Enable OCR</label>
 </div>
 <canvas id="pdf-canvas"></canvas>
 <div id="output"></div>
@@ -124,9 +125,11 @@ const annotatePdfBtn = document.getElementById("annotatePdf");
 const toggleDebug = document.getElementById("toggleDebug");
 const costInput = document.getElementById("costMultiplier");
 const poInput = document.getElementById("poNumber");
+const ocrToggle = document.getElementById("ocrToggle");
 const processBtn = document.getElementById("processBtn");
 let costMultiplier = parseFloat(costInput.value) || 0.95;
 let poNumber = poInput.value || "";
+let ocrEnabled = ocrToggle.checked;
 let cleanData = [];
 let totalWeight = 0;
 let originalPdfBytes;
@@ -137,7 +140,6 @@ function updateSummary() {
 }
 
 const featureStatus = {
-  ocr: typeof Tesseract !== 'undefined',
   dragDrop: true,
   multiPage: true,
   costConfig: true,
@@ -147,7 +149,6 @@ const featureStatus = {
 
 function featureSummary() {
   return [
-    `OCR: ${featureStatus.ocr ? 'implemented' : 'NOT implemented'}`,
     `Drag and Drop: ${featureStatus.dragDrop ? 'implemented' : 'NOT implemented'}`,
     `Multi-page PDF: ${featureStatus.multiPage ? 'implemented' : 'NOT implemented'}`,
     `Configurable Cost Multiplier: ${featureStatus.costConfig ? 'implemented' : 'NOT implemented'}`,
@@ -185,6 +186,10 @@ costInput.addEventListener("input", () => {
 
 poInput.addEventListener("input", () => {
   poNumber = poInput.value;
+});
+
+ocrToggle.addEventListener("change", () => {
+  ocrEnabled = ocrToggle.checked;
 });
 
 fileElem.addEventListener("change", e => {
@@ -245,7 +250,7 @@ async function handleFiles(files) {
         }
       });
 
-      if (textContent.items.length === 0) {
+      if (ocrEnabled && textContent.items.length === 0) {
         const { data: { text } } = await Tesseract.recognize(canvas, 'eng');
         text.split(/\r?\n/).map(l => l.trim()).filter(Boolean).forEach(line => {
           extractedLines.push(line);

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # PurchasingPlateWeight
 Purchasing has been manually adding printed PDFs and multiplying for cost. HTML Doc to automate.
 
-- OCR via Tesseract.js has been disabled. Run OCR externally if the PDF does
-  not already contain selectable text.
+- OCR can be toggled on or off when processing files. Use the **Enable OCR**
+  checkbox next to the PO Number field if your PDF does not already contain
+  selectable text.
 ## Running
 1. Clone the repository or download the files.
 2. Serve the directory with a local web server (e.g. `python -m http.server`).
@@ -11,7 +12,9 @@ Purchasing has been manually adding printed PDFs and multiplying for cost. HTML 
    no extra installation is required.
 
 3. Use the file picker or drag-and-drop area to select your cut list PDF. After
-   choosing a file click the **Process PDF** button to parse it. The script
+   choosing a file click the **Process PDF** button to parse it. Enable the
+   **Enable OCR** checkbox if your file is a scanned PDF without selectable text.
+   The script
 
   extracts the weight values by grabbing the last numeric token from each line
   of the rightmost column. It sums these weights and displays the total along


### PR DESCRIPTION
## Summary
- add checkbox to enable OCR processing
- toggle OCR processing in script and expose `ocrEnabled`
- strip OCR status from debug feature summary
- document new OCR toggle in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685088530ef48324bbab5dea5a0f4da3