### PR TITLE
Fix line parsing for weights

### DIFF
--- a/Purchasing Plate Weight V1.06.html
+++ b/Purchasing Plate Weight V1.06.html
@@ -270,7 +270,8 @@ function processText(lines) {
   totalWeight = 0;
 
   lines.forEach(line => {
-    const matches = line.match(/\d+(?:\.\d+)?/g);
+    const normalized = line.replace(/(\d)\s+(?=\d)/g, '$1');
+    const matches = normalized.match(/\d+(?:\.\d+)?/g);
     if (matches && matches.length) {
       const last = parseFloat(matches[matches.length - 1]);
       if (!isNaN(last) && last > 0) {


### PR DESCRIPTION
## Summary
- normalize lines in `processText` to join split digits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68508e8ff6088324a2820d39c31c5f14